### PR TITLE
Added a setup step to ensure that the node exists before/after the test

### DIFF
--- a/src/main/scala/Investigation.scala
+++ b/src/main/scala/Investigation.scala
@@ -7,6 +7,8 @@ object Investigation {
 
     if (args.headOption.contains("read-mode")) {
       readNode(session)
+    } else if (args.headOption.contains("setup")) {
+      session.writeTransaction(queries.createNode)
     } else {
       queries.delay = args.headOption.getOrElse("0").toInt
       destroyAndRecreateNode(session)

--- a/src/main/scala/destroyAndRecreateNode.scala
+++ b/src/main/scala/destroyAndRecreateNode.scala
@@ -3,14 +3,11 @@ import scala.concurrent.duration._
 
 object destroyAndRecreateNode {
   def apply(session: Session): Unit = {
-    session.writeTransaction(queries.createNode)
 
     val deadline = 30.seconds.fromNow
 
     while(deadline.hasTimeLeft) {
       session.writeTransaction(queries.deleteAndCreateNode)
     }
-
-    session.writeTransaction(queries.deleteNode)
   }
 }


### PR DESCRIPTION
By having a separate setup step we can ensure that the node exists
before both the reader and the writer start executing. Otherwise, there
was a time-frame either if the reader starts earlier or if the writer
finishes earlier, where the node would not exist.